### PR TITLE
DevDungeon Level 2: getSumOfLitTorches mit Java Streams implementiert

### DIFF
--- a/devDungeon/src/level/devlevel/riddleHandler/TorchRiddleRiddleHandler.java
+++ b/devDungeon/src/level/devlevel/riddleHandler/TorchRiddleRiddleHandler.java
@@ -221,6 +221,14 @@ public class TorchRiddleRiddleHandler implements ITickable {
    * @return The sum of the values of all lit torches in the game.
    */
   private int getSumOfLitTorches() {
-    throw new UnsupportedOperationException("Not implemented yet.");
+      return Game.entityStream()  // 1. Holt alle Entities im Spiel
+          .filter(entity -> entity.isPresent(TorchComponent.class))  // 2. Nur Entities mit Fackel-Component
+          .filter(entity -> entity.fetch(TorchComponent.class)  // 3. Nur brennende Fackeln
+              .map(TorchComponent::lit)  // Prüft ob Fackel angezündet ist
+              .orElse(false))  // Falls keine TorchComponent, dann false
+          .mapToInt(entity -> entity.fetch(TorchComponent.class)  // 4. Holt den Wert jeder Fackel
+              .map(TorchComponent::value)  // Wert der Fackel
+              .orElse(0))  // Falls kein Wert, dann 0
+          .sum();  // 5. Summiert alle Werte
   }
 }


### PR DESCRIPTION
 Was ich gemacht habe

 DevDungeon Torch Riddle
- getSumOfLitTorches() Methode implementiert  mit Java Stream-API
- Ersetzt die defekte Methode die `UnsupportedOperationException` geworfen hat
- Verwendet moderne Stream-Operationen statt for-Schleifen

 Funktionsweise
- Holt alle Entities im Spiel mit `Game.entityStream()`
- Filtert nur Entities mit TorchComponent
- Filtert nur brennende Fackeln
- Summiert die Werte aller brennenden Fackeln

 Warum diese Änderung?
Die Methode war defekt und das Spiel-Rätsel funktionierte nicht. Jetzt kann das Torch Riddle in Level 2 korrekt gespielt werden.